### PR TITLE
Resolve error in BuccaneerCommon startup

### DIFF
--- a/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp
+++ b/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp
@@ -10,7 +10,6 @@ FBuccaneerCommonModule* FBuccaneerCommonModule::BuccaneerCommonModule = nullptr;
 
 void FBuccaneerCommonModule::StartupModule()
 {
-    Setup();
     CVarBuccaneerEnableStats = IConsoleManager::Get().RegisterConsoleVariable(
         TEXT("Buccaneer.EnableStats"),
         true,
@@ -22,7 +21,7 @@ void FBuccaneerCommonModule::StartupModule()
         true,
         TEXT("Disables the collection and logging of semantic events"),
         ECVF_Default);
-
+    Setup();
 }
 
 


### PR DESCRIPTION
Faced the following error when attempting to use the `Buccaneer` plugin.

```
Caught signal 11 Segmentation fault

libUnrealEditor-BuccaneerCommon.so!FBuccaneerCommonModule::Setup() [/<project_dir>/BuccaneerTest/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp:37]
libUnrealEditor-BuccaneerCommon.so!FBuccaneerCommonModule::StartupModule() [/<project_dir>/BuccaneerTest/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp:13]
libUnrealEditor-Core.so!FModuleManager::LoadModuleWithFailureReason(FName, EModuleLoadResult&, ELoadModuleFlags) [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Core/Private/Modules/ModuleManager.cpp:614]
libUnrealEditor-Projects.so!FModuleDescriptor::LoadModulesForPhase(ELoadingPhase::Type, TArray<FModuleDescriptor, TSizedDefaultAllocator<32> > const&, TMap<FName, EModuleLoadResult, FDefaultSetAllocator, TDefaultMapHashableKeyFuncs<FName, EModuleLoadResult, false> >&) [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Projects/Private/ModuleDescriptor.cpp:695]
libUnrealEditor-Projects.so!FPluginManager::TryLoadModulesForPlugin(FPlugin const&, ELoadingPhase::Type) const [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Projects/Private/PluginManager.cpp:2076]
libUnrealEditor-Projects.so!FPluginManager::LoadModulesForEnabledPlugins(ELoadingPhase::Type) [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Projects/Private/PluginManager.cpp:2154]
UnrealEditor!FEngineLoop::LoadStartupModules() [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Launch/Private/LaunchEngineLoop.cpp:4186]
UnrealEditor!FEngineLoop::PreInitPostStartupScreen(char16_t const*) [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Launch/Private/LaunchEngineLoop.cpp:3521]
UnrealEditor!GuardedMain(char16_t const*) [/<project_dir>/UnrealEngine/Engine/Source/./Runtime/Launch/Private/Launch.cpp:154]
libUnrealEditor-UnixCommonStartup.so!CommonUnixMain(int, char**, int (*)(char16_t const*), void (*)()) [/<project_dir>/UnrealEngine/Engine/Source/Runtime/Unix/UnixCommonStartup/Private/UnixCommonStartup.cpp:269]
libc.so.6!UnknownFunction(0x29d8f)
libc.so.6!__libc_start_main(+0x7f)
UnrealEditor!_start()
```

To replicate:
1. Create a blank C++ project
2. Copy `Plugins/Buccaneer` into the project
3. Attempt to open Unreal Engine

The fix was verified by successfully launching Unreal Engine, as well as verifying that stats are indeed being exported to Prometheus using the Compose files in the repo.