### PR TITLE
fix dangling stack reference in SendHTTP

### DIFF
--- a/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp
+++ b/Plugins/Buccaneer/Source/BuccaneerCommon/Private/BuccaneerCommon.cpp
@@ -134,9 +134,8 @@ void FBuccaneerCommonModule::SendHTTP(FString URL, TSharedPtr<FJsonObject> JsonO
     HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
     HttpRequest->SetVerb(TEXT("POST"));
     HttpRequest->SetContentAsString(body);
-    bool bInFlight = true;
     HttpRequest->OnProcessRequestComplete().BindLambda(
-        [&bInFlight](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
+        [](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
         {
             FString ResponseStr, ErrorStr;
 
@@ -158,8 +157,6 @@ void FBuccaneerCommonModule::SendHTTP(FString URL, TSharedPtr<FJsonObject> JsonO
             {
                 UE_LOG(BuccaneerCommon, Warning, TEXT("Push event response: %s"), *ErrorStr);
             }
-
-            bInFlight = false;
         });
     HttpRequest->ProcessRequest();
 }


### PR DESCRIPTION
The OnProcessRequestComplete lambda captures a local variable bInFlight, but the variable can become out of scope by the time the callback fires. This means that the callback can potentially write to a stack address that is already reassigned, thus corrupting whatever occupies that slot.

Because the bool has no further use outside of SendHTTP and the lambda, we can just fix this issue by removing it.